### PR TITLE
Only build necessary files into gem

### DIFF
--- a/aaf-mdqt.gemspec
+++ b/aaf-mdqt.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0.0'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = `git ls-files -z`.split("\x0")
+                                        .reject { |f| f.end_with?('.rake') }
+                                        .select { |f| f.start_with?('lib/', 'exe/') }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/lib/mdqt/version.rb
+++ b/lib/mdqt/version.rb
@@ -1,3 +1,3 @@
 module MDQT
-  VERSION = "0.8.9"
+  VERSION = "0.8.10"
 end


### PR DESCRIPTION
Resolves #19. Also excludes many other useless files (like rake tasks) which don't anger Dockle.