### PR TITLE
Feature/add ability to specify cli or not

### DIFF
--- a/lib/mdqt/cli/base.rb
+++ b/lib/mdqt/cli/base.rb
@@ -17,9 +17,10 @@ module MDQT
       end
 
       def self.check_requirements(options)
+        cli = options.cli?
 
         unless options.service == :not_required
-          abort "No MDQ service URL has been specified. Please use --service, MDQT_SERVICE or MDQ_BASE_URL" unless service_url(options).to_s.start_with?("http")
+          _halt! "No MDQ service URL has been specified. Please use --service, MDQT_SERVICE or MDQ_BASE_URL", cli unless service_url(options).to_s.start_with?("http")
         end
 
         if options.save_to
@@ -27,10 +28,10 @@ module MDQT
           begin
             FileUtils.mkdir_p(dir) unless File.exist?(dir)
           rescue
-            abort "Error: Directory #{dir} did not exist, and we can't create it"
+            _halt! "Error: Directory #{dir} did not exist, and we can't create it", cli
           end
-          abort "Error: '#{dir}' is not a writable directory!" if (File.directory?(dir) && !File.writable?(dir))
-          abort "Error: '#{dir}' is not a directory!" unless File.directory?(dir)
+          _halt! "Error: '#{dir}' is not a writable directory!", cli  if (File.directory?(dir) && !File.writable?(dir))
+          _halt! "Error: '#{dir}' is not a directory!", cli  unless File.directory?(dir)
         end
 
       end
@@ -163,6 +164,12 @@ module MDQT
       end
 
       def halt!(comment)
+        raise StandardError.new(comment) if options.cli?
+        abort pastel.red("Error: #{comment}")
+      end
+
+      def self._halt!(comment, cli)
+        raise StandardError.new(comment) if cli
         abort pastel.red("Error: #{comment}")
       end
 

--- a/lib/mdqt/cli/base.rb
+++ b/lib/mdqt/cli/base.rb
@@ -164,12 +164,12 @@ module MDQT
       end
 
       def halt!(comment)
-        raise StandardError.new(comment) if options.cli
+        raise StandardError.new(comment) unless options.cli
         abort pastel.red("Error: #{comment}")
       end
 
       def self._halt!(comment, cli)
-        raise StandardError.new(comment) if cli
+        raise StandardError.new(comment) unless cli
         abort pastel.red("Error: #{comment}")
       end
 

--- a/lib/mdqt/cli/base.rb
+++ b/lib/mdqt/cli/base.rb
@@ -17,7 +17,7 @@ module MDQT
       end
 
       def self.check_requirements(options)
-        cli = options.cli?
+        cli = options.cli
 
         unless options.service == :not_required
           _halt! "No MDQ service URL has been specified. Please use --service, MDQT_SERVICE or MDQ_BASE_URL", cli unless service_url(options).to_s.start_with?("http")
@@ -164,7 +164,7 @@ module MDQT
       end
 
       def halt!(comment)
-        raise StandardError.new(comment) if options.cli?
+        raise StandardError.new(comment) if options.cli
         abort pastel.red("Error: #{comment}")
       end
 

--- a/lib/mdqt/cli/defaults.rb
+++ b/lib/mdqt/cli/defaults.rb
@@ -22,6 +22,7 @@ module MDQT
             refresh: false,
             memcache: false,
             no_output: false,
+            cli: true,
           }
         end
 

--- a/lib/mdqt/cli/options.rb
+++ b/lib/mdqt/cli/options.rb
@@ -18,7 +18,7 @@ module MDQT
         :verbose,
         :memcache,
         :no_output,
-        :cli?,
+        :cli,
       ) do
         def initialize(**args)
           options = {
@@ -36,7 +36,7 @@ module MDQT
             verbose: nil,
             memcache: nil,
             no_output: nil,
-            cli?: true,
+            cli: true,
             **MDQT::CLI::Defaults.cli_defaults
           }
           super(**options, **args)

--- a/lib/mdqt/cli/options.rb
+++ b/lib/mdqt/cli/options.rb
@@ -18,6 +18,7 @@ module MDQT
         :verbose,
         :memcache,
         :no_output,
+        :cli?,
       ) do
         def initialize(**args)
           options = {
@@ -35,6 +36,7 @@ module MDQT
             verbose: nil,
             memcache: nil,
             no_output: nil,
+            cli?: true,
             **MDQT::CLI::Defaults.cli_defaults
           }
           super(**options, **args)

--- a/lib/mdqt/cli/options.rb
+++ b/lib/mdqt/cli/options.rb
@@ -36,7 +36,6 @@ module MDQT
             verbose: nil,
             memcache: nil,
             no_output: nil,
-            cli: true,
             **MDQT::CLI::Defaults.cli_defaults
           }
           super(**options, **args)

--- a/lib/mdqt/cli/url.rb
+++ b/lib/mdqt/cli/url.rb
@@ -13,7 +13,8 @@ module MDQT
                                   verbose:false,
                                   cache_type: :none,
                                   explain: false,
-                                  tls_cert_check: false)
+                                  tls_cert_check: false,
+                                  cli?: options.cli?)
 
         if args.empty?
           puts service_url(options)

--- a/lib/mdqt/cli/url.rb
+++ b/lib/mdqt/cli/url.rb
@@ -14,7 +14,7 @@ module MDQT
                                   cache_type: :none,
                                   explain: false,
                                   tls_cert_check: false,
-                                  cli?: options.cli?)
+                                  cli: options.cli)
 
         if args.empty?
           puts service_url(options)

--- a/lib/mdqt/client.rb
+++ b/lib/mdqt/client.rb
@@ -25,9 +25,10 @@ module MDQT
       @verbose         = options[:verbose] || false
       @explain         = options[:explain] || false
       @tls_cert_check  = options[:tls_risky] ? false : true
+      @cli  = options[:cli?]
       @cache_type = options[:cache_type] || :none
 
-      @md_service = MetadataService.new(@base_url, verbose: @verbose, cache_type: @cache_type, explain: @explain, tls_cert_check: tls_cert_check?)
+      @md_service = MetadataService.new(@base_url, verbose: @verbose, cache_type: @cache_type, explain: @explain, tls_cert_check: tls_cert_check?, cli?: @cli)
       @md_service.tidy_cache!
 
     end

--- a/lib/mdqt/client.rb
+++ b/lib/mdqt/client.rb
@@ -25,10 +25,10 @@ module MDQT
       @verbose         = options[:verbose] || false
       @explain         = options[:explain] || false
       @tls_cert_check  = options[:tls_risky] ? false : true
-      @cli  = options[:cli?]
+      @cli  = options[:cli]
       @cache_type = options[:cache_type] || :none
 
-      @md_service = MetadataService.new(@base_url, verbose: @verbose, cache_type: @cache_type, explain: @explain, tls_cert_check: tls_cert_check?, cli?: @cli)
+      @md_service = MetadataService.new(@base_url, verbose: @verbose, cache_type: @cache_type, explain: @explain, tls_cert_check: tls_cert_check?, cli: @cli)
       @md_service.tidy_cache!
 
     end

--- a/lib/mdqt/client/metadata_service.rb
+++ b/lib/mdqt/client/metadata_service.rb
@@ -29,7 +29,7 @@ module MDQT
         @store_config = options[:cache_store]
         @verbose = options[:verbose] ? true : false
         @explain = options[:explain] ? true : false
-        @cli = options[:cli?] ? true : false
+        @cli = options[:cli] ? true : false
         @tls_cert_check = options[:tls_cert_check] ? true : false
       end
 

--- a/lib/mdqt/client/metadata_service.rb
+++ b/lib/mdqt/client/metadata_service.rb
@@ -29,6 +29,7 @@ module MDQT
         @store_config = options[:cache_store]
         @verbose = options[:verbose] ? true : false
         @explain = options[:explain] ? true : false
+        @cli = options[:cli?] ? true : false
         @tls_cert_check = options[:tls_cert_check] ? true : false
       end
 
@@ -47,9 +48,9 @@ module MDQT
             req.options.open_timeout = 60
           end
         rescue Faraday::ConnectionFailed => oops
-          abort "Error - can't connect to MDQ service at URL #{base_url}: #{oops.to_s}"
+          MDQT::CLI::Base._halt! "Error - can't connect to MDQ service at URL #{base_url}: #{oops.to_s}", @cli
         rescue Faraday::TimeoutError => oops
-          abort "Error - connection to #{base_url} timed out!"
+          MDQT::CLI::Base._halt! "Error - connection to #{base_url} timed out!", @cli
         end
 
         MetadataResponse.new(entity_id, base_url, http_response, explain: explain?)
@@ -67,9 +68,9 @@ module MDQT
             req.options.open_timeout = 60
           end
         rescue Faraday::ConnectionFailed => oops
-          abort "Error - can't connect to MDQ service at URL #{base_url}: #{oops.to_s}"
+          MDQT::CLI::Base._halt! "Error - can't connect to MDQ service at URL #{base_url}: #{oops.to_s}", @cli
         rescue Faraday::TimeoutError => oops
-          abort "Error - connection to #{base_url} timed out!"
+          MDQT::CLI::Base._halt! "Error - connection to #{base_url} timed out!", @cli
         end
 
         http_response.status == 200
@@ -114,7 +115,7 @@ module MDQT
       end
 
       def validate_sha1!(sha1)
-        abort "Error: SHA1 identifier '#{sha1}' is malformed, halting" unless valid_sha1?(sha1)
+        MDQT::CLI::Base._halt! "Error: SHA1 identifier '#{sha1}' is malformed, halting", @cli unless valid_sha1?(sha1)
         sha1
       end
 


### PR DESCRIPTION
we then use this new bool to change aborts to raises

have both a static version and non static versions of the halt!

just results ina. more standardized response when used in a non cli context

part of https://github.com/ausaccessfed/validator-service/issues/1112